### PR TITLE
docs: Adjust README.md to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@
 [![REUSE status](https://api.reuse.software/badge/github.com/cap-js-community/sap-afc-sdk)](https://api.reuse.software/info/github.com/cap-js-community/sap-afc-sdk)
 [![Main CI](https://github.com/cap-js-community/sap-afc-sdk/actions/workflows/main-ci.yml/badge.svg)](https://github.com/cap-js-community/sap-afc-sdk/commits/main)
 
-### [SAP Advanced Financial Closing SDK for CDS](https://www.npmjs.com/package/@cap-js-community/sap-afc-sdk)
+## About this project
 
-> Provides an SDK for SAP Advanced Financial Closing to be consumed with
-> SAP Cloud Application Programming Model (Node.js).
+[SAP Advanced Financial Closing SDK for CDS](https://www.npmjs.com/package/@cap-js-community/sap-afc-sdk) Provides an SDK for SAP Advanced Financial Closing to be consumed with SAP Cloud Application Programming Model (Node.js).
 
-> ## Table of Contents
+## Table of Contents
 
 - [Getting Started](#getting-started)
 - [Architecture](#architecture)
@@ -22,6 +21,10 @@
   - [Add Features](#add-features)
   - [Deployment](#deployment)
   - [Advanced Setup](#advanced-setup)
+
+## Requirements and Setup
+
+*Insert a short description what is required to get your project running...*
 
 ## Getting Started
 
@@ -580,3 +583,15 @@ https://cap.cloud.sap/docs/guides/multitenancy/#enable-multitenancy
 
 The MTX Tool is used to manage the application lifecycle. It can be used to manage the application in Cloud Foundry.
 Details can be found at https://github.com/cap-js-community/mtx-tool.
+
+## Support, Feedback, Contributing
+
+This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/cap-js-community/<your-project>/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).
+
+## Code of Conduct
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone. By participating in this project, you agree to abide by its [Code of Conduct](CODE_OF_CONDUCT.md) at all times.
+
+## Licensing
+
+Copyright (20xx-)20xx SAP SE or an SAP affiliate company and <your-project> contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/cap-js-community/sap-afc-sdk).


### PR DESCRIPTION
Adjusted `README.md` to the template structure from https://github.com/cap-js-community/repository-template/blob/main/README.md

Still missing:
- Fill in the section _Requirements and Setup_
- Update the table of contents