### PR TITLE
test: Adjust `Reable` in test

### DIFF
--- a/srv/scheduling/processing-service.js
+++ b/srv/scheduling/processing-service.js
@@ -1,8 +1,6 @@
 "use strict";
 
 const cds = require("@sap/cds");
-const { Readable } = require("stream");
-const { text } = require("node:stream/consumers");
 
 const BaseApplicationService = require("../common/BaseApplicationService");
 
@@ -92,15 +90,6 @@ module.exports = class SchedulingProcessingService extends BaseApplicationServic
       })
       .where({ ID: job.ID });
     if (results && results.length > 0) {
-      for (const result of results) {
-        if (result.data) {
-          if (Buffer.isBuffer(result.data)) {
-            result.data = btoa(result.data);
-          } else if (result.data instanceof Readable) {
-            result.data = btoa(await text(result.data));
-          }
-        }
-      }
       const insertResults = await this.checkJobResults(req, results);
       await INSERT.into(JobResult).entries(insertResults);
     }

--- a/test/scheduling/processing.test.js
+++ b/test/scheduling/processing.test.js
@@ -368,7 +368,7 @@ describe("Processing Service", () => {
         name: "Stream",
         filename: "test.txt",
         mimeType: "text/plain",
-        data: Readable.from("This is a test"),
+        data: Readable.from("This is a test", { objectMode: false }),
       },
     ]);
     expect(result).toBeUndefined();


### PR DESCRIPTION
Adjust the `Reable.from` call to reflect the intent of the test case. 

As documented [here](https://nodejs.org/api/stream.html#streamreadablefromiterable-options:~:text=Readable.from()%20will%20set%20options.objectMode%20to%20true) the `objectMode` is `true` by default. Which means that `encoding` is not applied onto the `Readable` as the `values` pushed into the stream are `Objects`. When `objectMode` is disabled any `string` pushed into the stream will be converted to its underlying `Buffer` which converts it into unknown binary data and `encoding` logic will be applied when converting into a `string`.